### PR TITLE
use `dot: true` for minimatch

### DIFF
--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -47,9 +47,9 @@ export const createGlobMatcher = (patterns: string[]) => {
     let matched = false
     for (const pattern of patterns) {
       if (pattern.startsWith('!')) {
-        matched = matched && minimatch(target, pattern)
+        matched = matched && minimatch(target, pattern, { dot: true })
       } else {
-        matched = matched || minimatch(target, pattern)
+        matched = matched || minimatch(target, pattern, { dot: true })
       }
     }
     return matched


### PR DESCRIPTION
This project uses **minimatch**, but files starting with a dot were being ignored. For example: `.node-version`, `.eslintrc`, or `.dockerignore`.

In GitHub Actions, however, the `paths` filter matches dot-prefixed files as well. Based on that behavior, I believe it’s more appropriate to set `dot: true`, as done in this PR. What do you think?