### PR TITLE
Revert "Replace minimatch with path.matchesGlob"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@octokit/action": "8.0.4",
     "@octokit/plugin-retry": "8.1.0",
     "js-yaml": "4.1.1",
+    "minimatch": "10.2.5",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
+      minimatch:
+        specifier: 10.2.5
+        version: 10.2.5
       zod:
         specifier: 4.4.3
         version: 4.4.3

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,4 +1,4 @@
-import { matchesGlob } from 'node:path'
+import { minimatch } from 'minimatch'
 import * as z from 'zod'
 
 export const matchPullRequestType = (workflow: Workflow, type: string) => {
@@ -47,9 +47,9 @@ export const createGlobMatcher = (patterns: string[]) => {
     let matched = false
     for (const pattern of patterns) {
       if (pattern.startsWith('!')) {
-        matched = matched && !matchesGlob(target, pattern.slice(1))
+        matched = matched && minimatch(target, pattern, { dot: true })
       } else {
-        matched = matched || matchesGlob(target, pattern)
+        matched = matched || minimatch(target, pattern, { dot: true })
       }
     }
     return matched

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -10,6 +10,7 @@ describe('createGlobMatcher', () => {
   })
   it('matches it when a pattern is given', () => {
     const matcher = createGlobMatcher(['*.bar'])
+    expect(matcher('.github.foo.bar')).toBe(true)
     expect(matcher('github.foo.bar')).toBe(true)
     expect(matcher('github.foo.baz')).toBe(false)
   })
@@ -17,16 +18,20 @@ describe('createGlobMatcher', () => {
     const matcher = createGlobMatcher(['*', '!*.github.*'])
     expect(matcher('foo.github.bar')).toBe(false)
     expect(matcher('foo.github.baz')).toBe(false)
+    expect(matcher('.foo.github.baz')).toBe(false)
     expect(matcher('example.bar')).toBe(true)
     expect(matcher('example.baz')).toBe(true)
+    expect(matcher('.example.baz')).toBe(true)
   })
   it('takes higher precedence to the later pattern', () => {
     // https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#example-including-and-excluding-branches
     const matcher = createGlobMatcher(['*.bar', '!foo.*', '*.baz'])
     expect(matcher('foo.github.bar')).toBe(false)
     expect(matcher('foo.github.baz')).toBe(true)
+    expect(matcher('.foo.github.baz')).toBe(true)
     expect(matcher('example.bar')).toBe(true)
     expect(matcher('example.baz')).toBe(true)
+    expect(matcher('.example.baz')).toBe(true)
   })
 })
 


### PR DESCRIPTION
Reverts int128/list-matched-workflows-action#287

It breaks the dotfiles behavior such as `.github/`.
